### PR TITLE
updated ngen image tag to use IMAGE_TAG variable

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push image
+      - name: Build & push image (with NGEN_IMAGE_TAG)
+        if: env.NGEN_IMAGE_TAG != ''
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -75,6 +76,15 @@ jobs:
           tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
           build-args: |
             NGEN_IMAGE_TAG=${{ env.NGEN_IMAGE_TAG }}
+
+      - name: Build & push image (no build-args)
+        if: env.NGEN_IMAGE_TAG == ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
+
 
   unit-test:
     name: unit-test

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,24 +67,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push image (with NGEN_IMAGE_TAG)
-        if: env.NGEN_IMAGE_TAG != ''
+      - name: Build & push image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
           build-args: |
-            NGEN_IMAGE_TAG=${{ env.NGEN_IMAGE_TAG }}
-
-      - name: Build & push image (no build-args)
-        if: env.NGEN_IMAGE_TAG == ''
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
-
+            NGEN_IMAGE_TAG=${{ env.NGEN_IMAGE_TAG || 'latest' }}
 
   unit-test:
     name: unit-test

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
           push: true
           tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
           build-args: |
-            IMAGE_TAG=${{ needs.setup.outputs.test_image_tag }}
+            NGEN_IMAGE_TAG=${{ env.NGEN_IMAGE_TAG }}
 
   unit-test:
     name: unit-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 ARG IMAGE_TAG=latest
-# TODO: once ngen images are being built properly with latest tag, revert back
-FROM ghcr.io/ngwpc/ngen:pr-8-build
+FROM ghcr.io/ngwpc/ngen:${IMAGE_TAG}
 # Uncomment when building ngen locally
 #FROM ngen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
-ARG IMAGE_TAG=latest
-FROM ghcr.io/ngwpc/ngen:${IMAGE_TAG}
+ARG NGEN_IMAGE_TAG=latest
+FROM ghcr.io/ngwpc/ngen:${NGEN_IMAGE_TAG}
 # Uncomment when building ngen locally
 #FROM ngen
 


### PR DESCRIPTION
We were previously using testing tags from ngen to very that nwm-cal-mgr was working. Now that ngen pipeline build is working, we can change it back to use `:latest` or whichever tag the user specifies.