### PR TITLE
Fixed pydantic bugs in agent.py and calibration.py

### DIFF
--- a/python/calib/src/calib/agent.py
+++ b/python/calib/src/calib/agent.py
@@ -181,8 +181,8 @@ class Agent(BaseAgent):
 
     def create_valid_cmd(self, valid_config_file) -> str:
         """Build command for validation run."""
-        arg1 = self.model.__root__.catchments.resolve()
-        arg2 = self.model.__root__.nexus.resolve()
+        arg1 = self.model.catchments.resolve()
+        arg2 = self.model.nexus.resolve()
         valid_args = '{} "all" {} "all" {}'.format(arg1, arg2, valid_config_file)
 
         return "{} {}".format(self.model.get_binary(), valid_args)
@@ -256,11 +256,11 @@ class Agent(BaseAgent):
         # serialize a copy of the model
         # FIXME ??? if you do self.model.resolve_paths() here, the duplicated agent
         # doesn't have fully qualified paths...but if you do it in constructor, it works fine...
-        data = self.model.__root__.copy(deep=True)
+        data = self.model.model_copy(deep=True)
         # return a new agent, which has a unique Model instance
         # and its own Job/workspace
         return Agent(
-            data.dict(by_alias=True),
+            data.model_dump(by_alias=True),
             self._workdir,
             self._general,
             log=False,

--- a/python/calibration.py
+++ b/python/calibration.py
@@ -127,14 +127,14 @@ def main(general: General, model_conf):
             start_iteration = agent.restart()
         func = dds_set  # FIXME what about explicit/dds
     elif general.strategy.algorithm == Algorithm.pso:  # TODO how to restart PSO?
-        if agent.model.strategy != "uniform":
+        if agent.model.strategy.strategy != "uniform":
             LOG.warning("Can only use PSO with the uniform model strategy")
             return
         if general.restart:
             LOG.warning("Restart not supported for PSO search, starting at 0")
         func = pso_search
     elif general.strategy.algorithm == Algorithm.gwo:
-        if agent.model.strategy != "uniform":
+        if agent.model.strategy.strategy != "uniform":
             LOG.warning("Can only use GWO with the uniform model strategy")
             return
         if general.restart:


### PR DESCRIPTION
Bug fix for error raised when trying to run calibrations for GWO or PSO caused by deprecated Pydantic syntax (https://jira.nextgenwaterprediction.com/browse/NGWPC-7570).

## Additions

-

## Removals

-

## Changes

- Pydantic V2 bug fixes to agent.py and calibration.py to enable GWO and PSO calibration runs

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux
- [ ] MacOS
